### PR TITLE
0.3.0 - no more xmlhttprequest polyfill (for now)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Jealous of Node.js? Pining for clever callbacks? Request is for you.
 
 Don't care about Node.js? Looking for less tedium and a no-nonsense API? Request is for you too.
 
-[![browser support](https://ci.testling.com/maxogden/browser-request.png)](https://ci.testling.com/maxogden/browser-request)
+[![browser support](https://ci.testling.com/iriscouch/browser-request.png)](https://ci.testling.com/maxogden/browser-request)
 
 # Examples
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-request",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "author": {
     "name": "Jason Smith",
     "email": "jhs@iriscouch.com"
@@ -10,19 +10,17 @@
     "request",
     "http",
     "browser",
-    "ender",
     "browserify"
   ],
-  "homepage": "http://github.com/maxogden/browser-request",
+  "homepage": "http://github.com/iriscouch/browser-request",
   "repository": {
     "type": "git",
-    "url": "git://github.com/maxogden/browser-request"
+    "url": "git://github.com/iriscouch/browser-request"
   },
   "scripts": {
     "test": "beefy test.js"
   },
   "devDependencies": {
-    "tap": "0.1.3",
     "tape": "~1.0.4",
     "beefy": "~0.4.0",
     "browserify": "~2.25.0"

--- a/test.js
+++ b/test.js
@@ -3,18 +3,18 @@ var test = require('tape')
 var request = require('./')
 
 test('try a CORS GET', function (t) {
-  t.plan(2)
   var url = 'https://www.googleapis.com/plus/v1/activities'
   request(url, function(err, resp, body) {
     t.equal(resp.statusCode, 400)
     t.equal(!!resp.body.match(/Required parameter/), true)
+    t.end()
   })
 })
 
 test('json true', function (t) {
-  t.plan(1)
   var url = 'https://www.googleapis.com/plus/v1/activities'
   request({url: url, json: true}, function(err, resp, body) {
     t.equal(body.error.code, 400)
+    t.end()
   })
 })


### PR DESCRIPTION
this bumps the version to 0.3.0 so we can publish to npm. also fixes urls for the testling badge

can you add em as a collaborator to this repo and also `npm owners add browser-request maxogden`? cheers
