### PR TITLE
Don't stringify if there is not a body.

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function request(options, callback) {
 
     if(typeof options.json !== 'boolean')
       options.body = JSON.stringify(options.json)
-    else if(typeof options.body !== 'string')
+    else if(typeof options.body === 'object' && options.body !== null)
       options.body = JSON.stringify(options.body)
   }
 


### PR DESCRIPTION
Example:

``` js
request({ uri: 'some uri', json: true }, callback)
```

This will actually call `JSON.stringify` on `null` which results in the
string `'null'`.
