### PR TITLE
add bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "browser-request",
+  "description": "Browser port of the Node.js 'request' package",
+  "main": "index.js",
+  "keywords": [
+    "request",
+    "http",
+    "browser",
+    "browserify"
+  ],
+  "authors": [
+    "Jason Smith <jhs@iriscouch.com>"
+  ],
+  "version": "0.3.2",
+  "homepage": "https://github.com/voronianski/browser-request",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "test.js"
+  ]
+}


### PR DESCRIPTION
Bower is missing this cool library! You only need to run this command in your repo:

``` bash
bower register browser-request git://github.com/iriscouch/browser-request.git
```

It will be cool if you merge it ASAP! Thanks!
