### PR TITLE
Don’t calllback with JSON parse error

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,7 +271,7 @@ function run_xhr(options) {
     xhr.body = xhr.responseText
     if(options.json) {
       try        { xhr.body = JSON.parse(xhr.responseText) }
-      catch (er) { return options.callback(er, xhr)        }
+      catch (e) { }
     }
 
     options.callback(null, xhr, xhr.body)


### PR DESCRIPTION
It should be up to the caller to decide if a non-JSON body is actually an error state.

For example: you make a request where you expect a JSON response, but instead you get 204 No Content.  

It should be up to your application to decide what that means.
