### PR TITLE
Add support for {encoding:null} option and binary Buffer for body.

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,6 +196,10 @@ function run_xhr(options) {
 
   xhr.onreadystatechange = on_state_change
   xhr.open(options.method, options.uri, true) // asynchronous
+  // Deal with requests for raw buffer response
+  if(options.encoding === null) {
+    xhr.responseType = 'arraybuffer';
+  }
   if(is_cors)
     xhr.withCredentials = !! options.withCredentials
   xhr.send(options.body)
@@ -268,10 +272,14 @@ function run_xhr(options) {
     did.end = true
     request.log.debug('Request done', {'id':xhr.id})
 
-    xhr.body = xhr.responseText
-    if(options.json) {
-      try        { xhr.body = JSON.parse(xhr.responseText) }
-      catch (er) { return options.callback(er, xhr)        }
+    if(options.encoding === null) {
+      xhr.body = new Buffer(new Uint8Array(xhr.response));
+    } else {
+      xhr.body = xhr.responseText
+      if(options.json) {
+        try        { xhr.body = JSON.parse(xhr.responseText) }
+        catch (er) { return options.callback(er, xhr)        }
+      }
     }
 
     options.callback(null, xhr, xhr.body)


### PR DESCRIPTION
I need to be able to work with Buffers vs. JSON/text coming back from the server.  With request I can add the `encoding: null` option, and the callback will get a `Buffer` for the `body` arg.  This provides the same behaviour in a browser. 
