### PR TITLE
support options.blob

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,6 +196,8 @@ function run_xhr(options) {
 
   xhr.onreadystatechange = on_state_change
   xhr.open(options.method, options.uri, true) // asynchronous
+  if(options.blob)
+    xhr.responseType = 'blob'
   if(is_cors)
     xhr.withCredentials = !! options.withCredentials
   xhr.send(options.body)
@@ -268,7 +270,11 @@ function run_xhr(options) {
     did.end = true
     request.log.debug('Request done', {'id':xhr.id})
 
-    xhr.body = xhr.responseText
+    if(options.blob)
+      xhr.body = xhr.response;
+    else
+      xhr.body = xhr.responseText
+
     if(options.json) {
       try        { xhr.body = JSON.parse(xhr.responseText) }
       catch (er) { return options.callback(er, xhr)        }

--- a/test.js
+++ b/test.js
@@ -18,3 +18,12 @@ test('json true', function (t) {
     t.end()
   })
 })
+
+test('blob true', function (t) {
+  var url = 'http://lorempixel.com/100/100/'
+  request({url: url, blob: true}, function(err, resp, blob) {
+    t.equal(resp.statusCode, 200)
+    t.equal(!!blob.type.match(/^image/), true)
+    t.end()
+  })
+})


### PR DESCRIPTION
When `options.blob` is set, the xhr object is requested to treat the
response as a blob.
