### PR TITLE
Fix requesting a parsed URL object (node.js 'request' compatibility)

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,8 @@ function request(options, callback) {
   if(!options.uri && options.uri !== "")
     throw new Error("options.uri is a required argument");
 
+  if(typeof options.uri === "object")
+    options.uri = options.uri.href;
   if(typeof options.uri != "string")
     throw new Error("options.uri must be a string");
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 var test = require('tape')
 
 var request = require('./')
+var urlParser = require('url')
 
 test('try a CORS GET', function (t) {
   var url = 'https://www.googleapis.com/plus/v1/activities'
@@ -13,6 +14,14 @@ test('try a CORS GET', function (t) {
 
 test('json true', function (t) {
   var url = 'https://www.googleapis.com/plus/v1/activities'
+  request({url: url, json: true}, function(err, resp, body) {
+    t.equal(body.error.code, 400)
+    t.end()
+  })
+})
+
+test('parsed url', function (t) {
+  var url = urlParser.parse('https://www.googleapis.com/plus/v1/activities')
   request({url: url, json: true}, function(err, resp, body) {
     t.equal(body.error.code, 400)
     t.end()


### PR DESCRIPTION
The Node 'request' module allows options.uri to be a parsed object
from the 'url' module. In this case, the href property is set to
the original URL. Check for this property to restore compatibility
with browser-request/request.

e.g., this code works in node:

```
require('request')({uri: require('url').parse('http://npmjs.org/')}, function() {})
```

and now works with a browserified browser-request. Includes test case
