### PR TITLE
Add license information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,6 @@
       "iphone/6",
       "ipad/6"
     ]
-  }
+  },
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
Adds the license information to the `package.json`, so that it becomes visible and searchable in `npm`.
