### PR TITLE
Add license property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "email": "jhs@iriscouch.com"
   },
   "description": "Browser port of the Node.js 'request' package",
+  "license": "Apache-2.0",
   "keywords": [
     "request",
     "http",


### PR DESCRIPTION
This tiny PR adds `{"license":"Apache-2.0"}` to `package.json`, so that automated license audit tools can approve the package without digging into its contents.

Thanks!

K
