### PR TITLE
formData support for PUT and POST

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ function request(options, callback) {
   
   if(options.form){
     if(typeof options.form == 'string') throw('form name unsupported');
-    if(options.method === 'POST'){
+    if(options.method.toLowerCase() === 'post' || options.method.toLowerCase() === 'put'){
         var encoding = (options.encoding || 'application/x-www-form-urlencoded').toLowerCase();
         options.headers['content-type'] = encoding;
         switch(encoding){


### PR DESCRIPTION
Two fixes here:
1. Method can be manually set via method: 'post', so we need the method check to be not case sensitive #63 
2. Sometimes form data is required for PUT requests